### PR TITLE
Stop route execution on auth fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: 📊 Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: |

--- a/src/pages/api/auth.test.ts
+++ b/src/pages/api/auth.test.ts
@@ -1,30 +1,13 @@
-import { NextApiRequest, NextApiResponse } from 'next'
-import { NextResponse } from 'next/server'
-import { vi, describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest'
 
 import { isAuthorized } from './auth'
-const spy = vi.spyOn(NextResponse, 'next')
 
 describe('isAuthorized', () => {
-  it('should return 403 if the authorization header is not correct', () => {
-    const req = { headers: { authorization: 'wrong' } } as NextApiRequest
-    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as NextApiResponse
-
-    isAuthorized(req, res)
-
-    expect(res.status).toHaveBeenCalledWith(403)
-    expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' })
+  it('should return false if the authorization header is not correct', () => {
+    expect(isAuthorized('wrong')).toBe(false)
   })
 
-  it('should call .next() if the authorization header is correct', () => {
-    spy.mockClear()
-    const req = { headers: { authorization: process.env.AUTH_SECRET } } as NextApiRequest
-    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as NextApiResponse
-
-    isAuthorized(req, res)
-
-    expect(res.status).not.toHaveBeenCalled()
-    expect(res.json).not.toHaveBeenCalled()
-    expect(NextResponse.next).toHaveBeenCalledOnce()
+  it('should return true if the authorization header is correct', () => {
+    expect(isAuthorized(process.env.AUTH_SECRET as string)).toBe(true)
   })
 })

--- a/src/pages/api/auth.ts
+++ b/src/pages/api/auth.ts
@@ -1,10 +1,3 @@
-import { NextApiRequest, NextApiResponse } from 'next'
-import { NextResponse } from 'next/server'
-
-export const isAuthorized = (req: NextApiRequest, res: NextApiResponse) => {
-  if (req.headers.authorization !== process.env.AUTH_SECRET) {
-    console.log('Unauthorized')
-    return res.status(403).json({ error: 'Unauthorized' })
-  }
-  NextResponse.next()
+export const isAuthorized = (authorizationHeader?: string | null) => {
+  return authorizationHeader === process.env.AUTH_SECRET
 }

--- a/src/pages/api/fetchSlackFile.ts
+++ b/src/pages/api/fetchSlackFile.ts
@@ -5,7 +5,9 @@ import { slackClient } from '@/utils/slackClient'
 import { isAuthorized } from './auth'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  isAuthorized(req, res)
+  if (!isAuthorized(req.headers.authorization)) {
+    return res.status(403).json({ error: 'Unauthorized' })
+  }
 
   const { fileId } = req.query
   if (!fileId || typeof fileId !== 'string') {


### PR DESCRIPTION
Previously, we would keep executing a route after we sent a failure response. This restructures the auth check to stop execution upon sending the error response.